### PR TITLE
fix always send UTC format to API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-snapchat-ads/bin/activate
-            pylint tap_snapchat_ads -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,logging-format-interpolation,too-many-nested-blocks,too-many-statements,redefined-builtin,protected-access'
+            pylint tap_snapchat_ads -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,logging-format-interpolation,too-many-nested-blocks,too-many-statements,redefined-builtin,protected-access,raise-missing-from'
       - run:
           name: 'JSON Validator'
           command: |

--- a/tap_snapchat_ads/sync.py
+++ b/tap_snapchat_ads/sync.py
@@ -126,14 +126,14 @@ def process_records(catalog, #pylint: disable=too-many-branches
 
 
 def remove_minutes_local(dttm, timezone):
-    new_dttm = new_dttm = dttm.astimezone(timezone).replace(
-        minute=0, second=0, microsecond=0).strftime('%Y-%m-%dT%H:%M:%S%z')
+    new_dttm = dttm.astimezone(timezone).replace(
+        minute=0, second=0, microsecond=0).astimezone(pytz.timezone('UTC')).strftime('%Y-%m-%dT%H:%M:%SZ')
     return new_dttm
 
 
 def remove_hours_local(dttm, timezone):
-    new_dttm = new_dttm = dttm.astimezone(timezone).replace(
-        hour=0, minute=0, second=0, microsecond=0).strftime('%Y-%m-%dT%H:%M:%S%z')
+    new_dttm = dttm.astimezone(timezone).replace(
+        hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.timezone('UTC')).strftime('%Y-%m-%dT%H:%M:%SZ')
     return new_dttm
 
 # Sync a specific parent or child endpoint.


### PR DESCRIPTION
Duplicate of https://github.com/singer-io/tap-snapchat-ads/pull/2

When requesting stream campaign_stats_daily, I always got the error

Exception: 400, E1004: Invalid query parameters in request URL: [Invalid StartDateTime: 2020-06-17T00:00:00 0200]

My account is running on Europe/Berlin timezone. The API can not handle the timezone +0200 time extension. With this change, the timezone will be send to the API in UTC.

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
