### PR TITLE
implement exception chaining with 'from'

### DIFF
--- a/tap_snapchat_ads/client.py
+++ b/tap_snapchat_ads/client.py
@@ -106,11 +106,11 @@ def raise_for_error(response):
                 error_message = '{}, {}: {}'.format(status_code, error_code, debug_message)
                 LOGGER.error(error_message)
                 ex = get_exception_for_error_code(status_code)
-                raise ex(error_message)
+                raise ex(error_message) from error
             else:
-                raise SnapchatError(error)
-        except (ValueError, TypeError):
-            raise SnapchatError(error)
+                raise SnapchatError(error) from error
+        except (ValueError, TypeError) as err:
+            raise SnapchatError(err) from err
 
 class SnapchatClient: # pylint: disable=too-many-instance-attributes
     def __init__(self,
@@ -249,7 +249,7 @@ class SnapchatClient: # pylint: disable=too-many-instance-attributes
             LOGGER.error('{}'.format(err))
             LOGGER.error('response.headers = {}'.format(response.headers))
             LOGGER.error('response.reason = {}'.format(response.reason))
-            raise Exception(err)
+            raise
 
         return response_json
 

--- a/tap_snapchat_ads/sync.py
+++ b/tap_snapchat_ads/sync.py
@@ -303,7 +303,7 @@ def sync_endpoint(
                 except Exception as err:
                     LOGGER.error('{}'.format(err))
                     LOGGER.error('URL for Stream {}: {}'.format(stream_name, next_url))
-                    raise Exception(err)
+                    raise
 
                 # time_extracted: datetime when the data was extracted from the API
                 time_extracted = utils.now()
@@ -347,7 +347,7 @@ def sync_endpoint(
                             except Exception as err:
                                 LOGGER.error('{}'.format(err))
                                 # LOGGER.error('error record: {}'.format(record)) # COMMENT OUT
-                                raise Exception(err)
+                                raise
 
                             # verify primary_keys are in tansformed_record
                             if 'id' not in transformed_record or 'start_time' not in transformed_record:
@@ -398,7 +398,7 @@ def sync_endpoint(
                         except Exception as err:
                             LOGGER.error('{}'.format(err))
                             LOGGER.error('error record: {}'.format(record))
-                            raise Exception(err)
+                            raise
 
                         # verify primary_keys are in tansformed_record
                         for key in id_fields:


### PR DESCRIPTION
# Description of change
Fix exception chaining to use the from keyword where necessary to satisfy pylint check.

# Manual QA steps
 - None
 
# Risks
 - Changes to the specified exceptions in exception chaining, could result in an unintended exception being raised. Risk is minimal. 
 
# Rollback steps
 - revert this branch
