### PR TITLE
Fix 'End time should be after start time' error

### DIFF
--- a/tap_snapchat_ads/sync.py
+++ b/tap_snapchat_ads/sync.py
@@ -244,7 +244,7 @@ def sync_endpoint(
                 window_start_dt_str = remove_minutes_local(start_window, timezone)
                 window_end_dt_str = remove_minutes_local(end_window, timezone)
                 if window_start_dt_str == window_end_dt_str:
-                    window_end_dt_str = remove_hours_local(end_window + timedelta(
+                    window_end_dt_str = remove_minutes_local(end_window + timedelta(
                         hours=1), timezone)
 
             params[bookmark_query_field_from] = window_start_dt_str


### PR DESCRIPTION
# Description of change
Snapchat returns an HTTP 400 error for the `campaign_stats_hourly` endpoint saying `End time should be after start time` when running the tap on a Sunday (since on that day the start and end day are the same for a `date_window_size` of a week).

Example of the URL params that caused this error in my logs:
```
start_time=2021-08-15T19:00:00Z&end_time=2021-08-15T07:00:00Z
```

This is caused by a wrong call in the `sync_endpoint` method. This PR fixes this
 
# Rollback steps
 - revert this branch
