### PR TITLE
Fix failing integration tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -26,7 +26,10 @@ class SnapchatBase(unittest.TestCase):
     OBEYS_START_DATE = "obey-start-date"
 
     # TDL-21946 Work-Item to generate test data for following list of streams
-    stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats", "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily", "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly"}
+    stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats",
+                     "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily",
+                     "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly",
+                     "targeting_interests_dlxp", "targeting_interests_plc"}
     # Currently there is no data available for following targeting streams
     missing_targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,6 +27,9 @@ class SnapchatBase(unittest.TestCase):
 
     stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats", "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily", "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly"}
 
+    # Currently there is no data available for following targeting streams
+    targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
+
     @staticmethod
     def tap_name():
         """The name of the tap"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ class SnapchatBase(unittest.TestCase):
     stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats", "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily", "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly"}
 
     # Currently there is no data available for following targeting streams
-    targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
+    failing_targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
 
     @staticmethod
     def tap_name():

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,10 +25,10 @@ class SnapchatBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     OBEYS_START_DATE = "obey-start-date"
 
+    # TDL-21946 Work-Item to generate test data for following list of streams
     stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats", "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily", "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly"}
-
     # Currently there is no data available for following targeting streams
-    failing_targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
+    missing_targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
 
     @staticmethod
     def tap_name():

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,8 +28,7 @@ class SnapchatBase(unittest.TestCase):
     # TDL-21946 Work-Item to generate test data for following list of streams
     stats_streams = {"ad_account_stats_daily", "ad_account_stats_hourly", "pixel_domain_stats",
                      "campaign_stats_daily", "campaign_stats_hourly", "ad_squad_stats_daily",
-                     "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly",
-                     "targeting_interests_dlxp", "targeting_interests_plc"}
+                     "ad_squad_stats_hourly", "ad_stats_daily",  "ad_stats_hourly"}
     # Currently there is no data available for following targeting streams
     missing_targeting_streams = {"targeting_interests_dlxp", "targeting_interests_plc"}
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -57,7 +57,8 @@ class SnapchatAllFieldsTest(SnapchatBase):
         },
         # cannot publish pixels, thus not able to get 'effective_status' of the pixel
         'pixels': {
-            'effective_status'
+            'effective_status',
+            'visible_to'
         },
         # These fields are not being replicated from the API, and it is confirmed by the support
         'roles': {
@@ -184,7 +185,7 @@ class SnapchatAllFieldsTest(SnapchatBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_streams() - self.stats_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.targeting_streams
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -185,7 +185,7 @@ class SnapchatAllFieldsTest(SnapchatBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_streams() - self.stats_streams - self.targeting_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.failing_targeting_streams
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -185,7 +185,7 @@ class SnapchatAllFieldsTest(SnapchatBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_streams() - self.stats_streams - self.failing_targeting_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.missing_targeting_streams
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -18,7 +18,7 @@ class SnapchatAutomaticFieldsTest(SnapchatBase):
         # when asked support about this, but this is known behavior from the API side
         # Please refer card: https://jira.talendforge.org/browse/TDL-18686 for more details
         known_failing_streams = {"targeting_android_versions"}
-        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams - self.failing_targeting_streams
+        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams - self.missing_targeting_streams
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -18,7 +18,7 @@ class SnapchatAutomaticFieldsTest(SnapchatBase):
         # when asked support about this, but this is known behavior from the API side
         # Please refer card: https://jira.talendforge.org/browse/TDL-18686 for more details
         known_failing_streams = {"targeting_android_versions"}
-        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams
+        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams - self.targeting_streams
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -18,7 +18,7 @@ class SnapchatAutomaticFieldsTest(SnapchatBase):
         # when asked support about this, but this is known behavior from the API side
         # Please refer card: https://jira.talendforge.org/browse/TDL-18686 for more details
         known_failing_streams = {"targeting_android_versions"}
-        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams - self.targeting_streams
+        expected_streams = self.expected_streams() - known_failing_streams - self.stats_streams - self.failing_targeting_streams
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -52,7 +52,7 @@ class SnapchatBookmarksTest(SnapchatBase):
         conn_id = connections.ensure_connection(self, original_properties=False)
         runner.run_check_mode(self, conn_id)
 
-        expected_streams = self.expected_streams() - self.stats_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.targeting_streams
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         self.select_found_catalogs(conn_id, found_catalogs, only_streams=expected_streams)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -52,7 +52,7 @@ class SnapchatBookmarksTest(SnapchatBase):
         conn_id = connections.ensure_connection(self, original_properties=False)
         runner.run_check_mode(self, conn_id)
 
-        expected_streams = self.expected_streams() - self.stats_streams - self.failing_targeting_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.missing_targeting_streams
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         self.select_found_catalogs(conn_id, found_catalogs, only_streams=expected_streams)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -52,7 +52,7 @@ class SnapchatBookmarksTest(SnapchatBase):
         conn_id = connections.ensure_connection(self, original_properties=False)
         runner.run_check_mode(self, conn_id)
 
-        expected_streams = self.expected_streams() - self.stats_streams - self.targeting_streams
+        expected_streams = self.expected_streams() - self.stats_streams - self.failing_targeting_streams
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         self.select_found_catalogs(conn_id, found_catalogs, only_streams=expected_streams)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -53,7 +53,7 @@ class SnapchatPaginationTest(SnapchatBase):
         - Verify by pks that the data replicated matches the data we expect.
         """
 
-        expected_streams = streams - self.failing_targeting_streams
+        expected_streams = streams - self.missing_targeting_streams
         conn_id = connections.ensure_connection(self)
 
         # Select all streams and all fields within streams

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -53,7 +53,7 @@ class SnapchatPaginationTest(SnapchatBase):
         - Verify by pks that the data replicated matches the data we expect.
         """
 
-        expected_streams = streams
+        expected_streams = streams - self.targeting_streams
         conn_id = connections.ensure_connection(self)
 
         # Select all streams and all fields within streams

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -53,7 +53,7 @@ class SnapchatPaginationTest(SnapchatBase):
         - Verify by pks that the data replicated matches the data we expect.
         """
 
-        expected_streams = streams - self.targeting_streams
+        expected_streams = streams - self.failing_targeting_streams
         conn_id = connections.ensure_connection(self)
 
         # Select all streams and all fields within streams

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -16,7 +16,7 @@ class SnapchatStartDateTest(SnapchatBase):
         expected_streams_1 = {"organizations", "ad_accounts", "audience_segments", "product_catalogs", "product_sets", "campaigns"}
         expected_streams_2 = {"billing_centers"}
         expected_streams_3 = {"members"}
-        expected_streams_4 = self.expected_streams() - self.stats_streams - self.targeting_streams -  streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
+        expected_streams_4 = self.expected_streams() - self.stats_streams - self.failing_targeting_streams -  streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
 
         self.run_test(expected_streams_1, "2021-01-01T00:00:00Z", "2022-04-21T00:00:00Z")
         self.run_test(expected_streams_2, "2022-04-01T00:00:00Z", "2022-04-28T00:00:00Z")

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -16,7 +16,7 @@ class SnapchatStartDateTest(SnapchatBase):
         expected_streams_1 = {"organizations", "ad_accounts", "audience_segments", "product_catalogs", "product_sets", "campaigns"}
         expected_streams_2 = {"billing_centers"}
         expected_streams_3 = {"members"}
-        expected_streams_4 = self.expected_streams() - self.stats_streams - streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
+        expected_streams_4 = self.expected_streams() - self.stats_streams - self.targeting_streams -  streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
 
         self.run_test(expected_streams_1, "2021-01-01T00:00:00Z", "2022-04-21T00:00:00Z")
         self.run_test(expected_streams_2, "2022-04-01T00:00:00Z", "2022-04-28T00:00:00Z")

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -16,7 +16,7 @@ class SnapchatStartDateTest(SnapchatBase):
         expected_streams_1 = {"organizations", "ad_accounts", "audience_segments", "product_catalogs", "product_sets", "campaigns"}
         expected_streams_2 = {"billing_centers"}
         expected_streams_3 = {"members"}
-        expected_streams_4 = self.expected_streams() - self.stats_streams - self.failing_targeting_streams -  streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
+        expected_streams_4 = self.expected_streams() - self.stats_streams - self.missing_targeting_streams -  streams_with_one_records - expected_streams_1 - expected_streams_2 - expected_streams_3
 
         self.run_test(expected_streams_1, "2021-01-01T00:00:00Z", "2022-04-21T00:00:00Z")
         self.run_test(expected_streams_2, "2022-04-01T00:00:00Z", "2022-04-28T00:00:00Z")


### PR DESCRIPTION
# Description of change
This PR Fixes integration tests by skipping the streams that have no data available for stitch's test account

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
