### PR TITLE
Handle 'NoneType' object has no attribute 'replace' for missing config params

### DIFF
--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -305,6 +305,11 @@ class SnapchatAds:
         start_date = config.get('start_date')
         swipe_up_attribution_window = config.get('swipe_up_attribution_window', '28_DAY')
         view_attribution_window = config.get('view_attribution_window', '7_DAY')
+        # after editing the configurations on integration page, sync is failing because all optional
+        # parameters are having null values in config.json
+        # so sync fails with `None object has no replace attribute`
+        swipe_up_attribution_window = '28_DAY' if not swipe_up_attribution_window else swipe_up_attribution_window
+        view_attribution_window = '7_DAY' if not view_attribution_window else view_attribution_window
 
         swipe_up_attr = int(swipe_up_attribution_window.replace('_DAY', ''))
 
@@ -316,10 +321,12 @@ class SnapchatAds:
         attribution_window = max(1, swipe_up_attr, view_attr)
 
         omit_empty = config.get('omit_empty', 'true')
+        omit_empty = 'true' if not omit_empty else omit_empty
         if '_stats_' in stream_name:
             params['omit_empty'] = omit_empty
 
-        country_codes = config.get('targeting_country_codes', 'us').replace(' ', '').lower()
+        country_codes = 'us' if not config.get('targeting_country_codes', 'us') else config.get('targeting_country_codes', 'us')
+        country_codes = country_codes.replace(' ', '').lower()
         if targeting_country_ind:
             country_code_list = country_codes.split(',')
         else:

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -303,13 +303,8 @@ class SnapchatAds:
 
         # tap config variabless
         start_date = config.get('start_date')
-        swipe_up_attribution_window = config.get('swipe_up_attribution_window', '28_DAY')
-        view_attribution_window = config.get('view_attribution_window', '7_DAY')
-        # after editing the configurations on integration page, sync is failing because all optional
-        # parameters are having null values in config.json
-        # so sync fails with `None object has no replace attribute`
-        swipe_up_attribution_window = '28_DAY' if not swipe_up_attribution_window else swipe_up_attribution_window
-        view_attribution_window = '7_DAY' if not view_attribution_window else view_attribution_window
+        swipe_up_attribution_window = config.get('swipe_up_attribution_window') or '28_DAY'
+        view_attribution_window = config.get('view_attribution_window') or '7_DAY'
 
         swipe_up_attr = int(swipe_up_attribution_window.replace('_DAY', ''))
 
@@ -320,12 +315,11 @@ class SnapchatAds:
 
         attribution_window = max(1, swipe_up_attr, view_attr)
 
-        omit_empty = config.get('omit_empty', 'true')
-        omit_empty = 'true' if not omit_empty else omit_empty
+        omit_empty = config.get('omit_empty') or 'true'
         if '_stats_' in stream_name:
             params['omit_empty'] = omit_empty
 
-        country_codes = 'us' if not config.get('targeting_country_codes', 'us') else config.get('targeting_country_codes', 'us')
+        country_codes = config.get('targeting_country_codes') or 'us'
         country_codes = country_codes.replace(' ', '').lower()
         if targeting_country_ind:
             country_code_list = country_codes.split(',')


### PR DESCRIPTION
# Description of change
Fall back to default values for missing config param values.
This PR fixes following error when user doesn't set the optional params. Somehow app is generating `keys` with `None` values in config files
```
INFO START Syncing: organizations
CRITICAL 'NoneType' object has no attribute 'replace'
Traceback (most recent call last):
  File "/code/orchestrator/tap-env/bin/tap-snapchat-ads", line 33, in <module>
    sys.exit(load_entry_point('tap-snapchat-ads==0.1.1', 'console_scripts', 'tap-snapchat-ads')())
  File "/code/orchestrator/tap-env/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped 
    return fnc(*args, **kwargs)
  File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_snapchat_ads/__init__.py", line 53, in main
       _sync(client=client,
  File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_snapchat_ads/sync.py", line 54, in sync
   total_records = stream_obj.sync_endpoint(
  File "/code/orchestrator/tap-env/lib/python3.9/site-packages/tap_snapchat_ads/streams.py", line 309, in sync_endpoint
   swipe_up_attr = int(swipe_up_attribution_window.replace('_DAY', ''))
AttributeError: 'NoneType' object has no attribute 'replace'
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
