### PR TITLE
Address community prs/Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.1.2
+  * Fall back to default values for un-configured optional params [#25](https://github.com/singer-io/tap-snapchat-ads/pull/25)
+  * Fix `End time should be after start time` error [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)
+  * Fix URL creation using `urlencode` [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)
 
 ## 0.1.1
   * Added mechanism to extract data for selected profiles [#22](https://github.com/singer-io/tap-snapchat-ads/pull/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 ## 0.1.2
   * Fall back to default values for un-configured optional params [#25](https://github.com/singer-io/tap-snapchat-ads/pull/25)
-  * Fix `End time should be after start time` error [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)
-  * Fix URL creation using `urlencode` [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)
+  * Fixes following issues [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)
+    * `End time should be after start time` error
+    *  URL creation using `urlencode`
 
 ## 0.1.1
   * Added mechanism to extract data for selected profiles [#22](https://github.com/singer-io/tap-snapchat-ads/pull/22)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-snapchat-ads',
-      version='0.1.1',
+      version='0.1.2',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -382,7 +382,7 @@ class SnapchatAds:
                     if window_start_dt_str == window_end_dt_str:
                         # E1008: Unsupported Stats Query: End time should be after start time.
                         # Snapchat ADs throws above error if both start and end_time are equal.
-                        # add delta of one hour and remove minutes from it.
+                        # add delta of one hour to end_window and remove minutes from it.
                         window_end_dt_str = self.remove_minutes_local(end_window + timedelta(
                             hours=1), timezone)
 

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -380,7 +380,10 @@ class SnapchatAds:
                     window_start_dt_str = self.remove_minutes_local(start_window, timezone)
                     window_end_dt_str = self.remove_minutes_local(end_window, timezone)
                     if window_start_dt_str == window_end_dt_str:
-                        window_end_dt_str = self.remove_hours_local(end_window + timedelta(
+                        # E1008: Unsupported Stats Query: End time should be after start time.
+                        # Snapchat ADs throws above error if both start and end_time are equal.
+                        # add delta of one hour and remove minutes from it.
+                        window_end_dt_str = self.remove_minutes_local(end_window + timedelta(
                             hours=1), timezone)
 
                 params[bookmark_query_field_from] = window_start_dt_str

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -176,15 +176,10 @@ class SnapchatAds:
 
         with metrics.record_counter(stream_name) as counter:
             for record in records:
-                # Read and store the ad_account's timezone incase the user not selected the timezone
-                # field, this field value is required to transform the start and end window date
-                # from ad_account's timezone to UTC timezone.
-                if stream_name == "ad_accounts":
-                    ad_account_time_zone = record.get("timezone", None)
                 # Transform record for Singer.io
                 with Transformer() as transformer:
                     transformed_record = transformer.transform(
-                        record,
+                        dict(record),
                         schema,
                         stream_metadata)
 
@@ -210,11 +205,6 @@ class SnapchatAds:
                     else:
                         self.write_record(stream_name, transformed_record, time_extracted=time_extracted)
                         counter.increment()
-
-                    if stream_name == "ad_accounts" and "timezone" not in record:
-                        # Write the timezone value to original record if it's not selected by the user
-                        record["timezone"] = ad_account_time_zone
-
 
             LOGGER.info('Stream: {}, Processed {} records'.format(stream_name, counter.value))
             return max_bookmark_value, counter.value

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -304,8 +304,8 @@ class SnapchatAds:
 
         # tap config variabless
         start_date = config.get('start_date')
-        swipe_up_attribution_window = config.get('swipe_up_attribution_window', '28_DAY')
-        view_attribution_window = config.get('view_attribution_window', '7_DAY')
+        swipe_up_attribution_window = config.get('swipe_up_attribution_window') or '28_DAY'
+        view_attribution_window = config.get('view_attribution_window') or '7_DAY'
 
         swipe_up_attr = int(swipe_up_attribution_window.replace('_DAY', ''))
 
@@ -316,11 +316,12 @@ class SnapchatAds:
 
         attribution_window = max(1, swipe_up_attr, view_attr)
 
-        omit_empty = config.get('omit_empty', 'true')
+        omit_empty = config.get('omit_empty') or 'true'
         if '_stats_' in stream_name:
             params['omit_empty'] = omit_empty
 
-        country_codes = config.get('targeting_country_codes', 'us').replace(' ', '').lower()
+        country_codes = config.get('targeting_country_codes') or 'us'
+        country_codes = country_codes.replace(' ', '').lower()
         if targeting_country_ind:
             country_code_list = country_codes.split(',')
         else:


### PR DESCRIPTION
# Description of change
Duplicates [**#11**](https://github.com/singer-io/tap-snapchat-ads/pull/11) and [**#4**](https://github.com/singer-io/tap-snapchat-ads/pull/4)

- Fixes `End time should be after start time` error when start_time window and end_time window values are equal (this is a very rare case)
- Uses `urlencode` to create encoded queryParams (also fixes [Issue #9 ](https://github.com/singer-io/tap-snapchat-ads/issues/9))
- sends record as `dict(record)` to singer-transform to keep the original record, Prevents API from throwing this error `Timeseries queries with DAY granularity must have a start time that is the start of day (00:00:00) for the account's timezone. This account's timezone  is: America/New_York`. This scenario happens only if the user doesn't selected timezone field in ad_accounts stream
- #25 Merged

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
