### PR TITLE
TDL-24535 / TDL-22326: Use tz.gettz instead of pytz.timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 0.1.3
+  * Uses tz.gettz instead of pytz.timezone to deal with dst issues #[28](https://github.com/singer-io/tap-snapchat-ads/pull/28)
+
 ## 0.1.2
   * Fall back to default values for un-configured optional params [#25](https://github.com/singer-io/tap-snapchat-ads/pull/25)
   * Fixes following issues [#26](https://github.com/singer-io/tap-snapchat-ads/pull/26)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-snapchat-ads',
-      version='0.1.2',
+      version='0.1.3',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -21,6 +21,7 @@ import pytz
 import math
 import humps
 from datetime import timedelta
+from dateutil import tz
 from urllib.parse import urlencode
 import singer
 from singer import Transformer, metadata, metrics, utils
@@ -329,9 +330,9 @@ class SnapchatAds:
 
         # Get the timezone and latest bookmark for the stream
         if not timezone_desc:
-            timezone = pytz.timezone('UTC')
+            timezone = tz.gettz("UTC")
         else:
-            timezone = pytz.timezone(timezone_desc)
+            timezone = tz.gettz(timezone_desc)
         LOGGER.info('timezone = {}'.format(timezone))
 
         last_datetime = self.get_bookmark(state, stream_name, start_date, bookmark_field, parent, parent_id)


### PR DESCRIPTION
# Description of change
Addresses daylight savings / standard time query window issues stemming from conversions to midnight in the local time for daily granularity

# Manual QA steps
 - tested with a local connection
 
# Risks
 - low; corrective action
 
# Rollback steps
 - revert this branch
