### PR TITLE
handle org_account_ids config property as list or json-encoded string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-snapchat-ads/bin/activate
-            pylint tap_snapchat_ads -d C,W,R
+            pylint tap_snapchat_ads -d C,W,R,E0606
       - run:
           name: 'JSON Validator'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0
+  * Handle `org_account_ids` config property as list or json-encoded string [#30](https://github.com/singer-io/tap-snapchat-ads/pull/30)
+
 ## 0.1.4
   * Bumps requests package [#27](https://github.com/singer-io/tap-snapchat-ads/pull/27)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-snapchat-ads',
-      version='0.1.4',
+      version='0.2.0',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_snapchat_ads/__init__.py
+++ b/tap_snapchat_ads/__init__.py
@@ -27,12 +27,19 @@ def do_discover():
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
+def maybe_parse_org_account_ids(config):
+    """Converts org_account_ids into a list if it is a JSON-encoded string."""
+    if isinstance(config["org_account_ids"], str):
+        try:
+            config.update(org_account_ids = json.loads(config["org_account_ids"]))
+        except json.JSONDecodeError:
+            raise
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():
 
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-
+    maybe_parse_org_account_ids(parsed_args.config)
     with SnapchatClient(parsed_args.config['client_id'],
                         parsed_args.config['client_secret'],
                         parsed_args.config['refresh_token'],

--- a/tap_snapchat_ads/__init__.py
+++ b/tap_snapchat_ads/__init__.py
@@ -33,7 +33,7 @@ def maybe_parse_org_account_ids(config):
         try:
             config.update(org_account_ids = json.loads(config["org_account_ids"]))
         except json.JSONDecodeError as e:
-            raise ValueError(f"Error parsing org_account_ids string: {e}")
+            raise ValueError(f"Error parsing org_account_ids string: {e}") from e
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():

--- a/tap_snapchat_ads/__init__.py
+++ b/tap_snapchat_ads/__init__.py
@@ -32,8 +32,8 @@ def maybe_parse_org_account_ids(config):
     if isinstance(config["org_account_ids"], str):
         try:
             config.update(org_account_ids = json.loads(config["org_account_ids"]))
-        except json.JSONDecodeError:
-            raise
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error parsing org_account_ids string: {e}")
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,0 +1,39 @@
+import unittest
+from tap_snapchat_ads import maybe_parse_org_account_ids
+
+
+class TestMaybeParseOrgAccountIds(unittest.TestCase):
+    config_with_list = {'org_account_ids':
+                        [{'organisation_id': 'id1', 'ad_accounts': []},
+                         {'organisation_id': 'id2', 'ad_accounts': ['ad_id1', 'ad_id2']}],
+                        'start_date': '2024-02-24T00:00:00Z',}
+
+    config_with_string = {'org_account_ids':
+                          "[{\"organisation_id\":\"id1\",\"ad_accounts\":[]},{\"organisation_id\":\"id2\",\"ad_accounts\":[\"ad_id1\",\"ad_id2\"]}]",
+                          'start_date': '2024-02-24T00:00:00Z',}
+
+    config_with_bad_type = {'org_account_ids':
+                            12345,
+                            'start_date': '2024-02-24T00:00:00Z',}
+
+    def test_with_list(self):
+        """Test that config with org_account_ids of type list remains unchanged"""
+        self.assertIsInstance(self.config_with_list["org_account_ids"], list)
+        maybe_parse_org_account_ids(self.config_with_list)
+        self.assertIsInstance(self.config_with_list["org_account_ids"], list)
+        self.assertEqual(self.config_with_list["start_date"], '2024-02-24T00:00:00Z')
+
+    def test_with_string(self):
+        """Test that config with org_account_ids of type string is converted to type list"""
+        self.assertIsInstance(self.config_with_string["org_account_ids"], str)
+        maybe_parse_org_account_ids(self.config_with_string)
+        self.assertIsInstance(self.config_with_string["org_account_ids"], list)
+        self.assertEqual(self.config_with_string["start_date"], '2024-02-24T00:00:00Z')
+        self.assertEqual(self.config_with_string, self.config_with_list)
+
+    def test_with_bad_type(self):
+        """Test that config with org_account_ids with unexpected type is unchanged by the function"""
+        self.assertIsInstance(self.config_with_bad_type["org_account_ids"], int)
+        maybe_parse_org_account_ids(self.config_with_bad_type)
+        self.assertIsInstance(self.config_with_bad_type["org_account_ids"], int)
+        self.assertEqual(self.config_with_bad_type["start_date"], '2024-02-24T00:00:00Z')


### PR DESCRIPTION
# Description of change
Allow `org_account_ids` config property to be input as a list or json-encoded string. Updates the tap to parse the string if present.

# Manual QA steps
 - Added unittests
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
