### PR TITLE
Convert child streams replication method to as of parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0
+  * Converted child streams (`members`, `roles`, `pixel_domain_stats`, `product_sets`) to `INCREMENTAL` replication using their parent streams' replication timestamps, and added composite parent keys for coordinated bookmarking. [#41](https://github.com/singer-io/tap-snapchat-ads/pull/41)
+
 ## 0.3.0
   * Metadata update [#35](https://github.com/singer-io/tap-snapchat-ads/pull/35)
   * Update Python version to 3.12

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-snapchat-ads',
-      version='0.3.0',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -90,6 +90,7 @@ class SnapchatAds:
     parent_stream = None
     parent = None
     parent_key_property = None
+    parent_replication_key = None
     grandparent_stream = None
     great_grandparent_stream = None
     json_schema = None
@@ -306,7 +307,8 @@ class SnapchatAds:
             sync_streams,
             selected_streams,
             timezone_desc=None,
-            parent_id=None):
+            parent_id=None,
+            parent_record=None):
         
         """
         To sync all streams (i.e. parent and child stream)
@@ -315,7 +317,7 @@ class SnapchatAds:
         # endpoint_config variables
         base_path = stream_class.path or stream_name
         bookmark_field = next(iter(stream_class.replication_keys ), None)
-        params = stream_class.params
+        params = dict(stream_class.params)
         paging = stream_class.paging
         bookmark_query_field_from = stream_class.bookmark_query_field_from
         bookmark_query_field_to = stream_class.bookmark_query_field_to
@@ -327,6 +329,7 @@ class SnapchatAds:
         id_fields = stream_class.key_properties
         parent = stream_class.parent
         parent_key_property = stream_class.parent_key_property
+        parent_replication_key = stream_class.parent_replication_key
         is_stats_stream = '_stats_' in stream_name or stream_name.endswith('_stats')
         date_window_size = int(stream_class.date_window_size)
         # Store parent_id into base_parent for bookmark writing
@@ -511,6 +514,11 @@ class SnapchatAds:
                                 if parent and parent_id:
                                     parent_key = parent_key_property or '{}_id'.format(parent)
                                     record.setdefault(parent_key, parent_id)
+                                if parent_replication_key and parent_record:
+                                    record.setdefault(
+                                        parent_replication_key,
+                                        parent_record.get(parent_replication_key),
+                                    )
 
                                 # De-nest stats
                                 stats = record.get('stats', {})
@@ -525,12 +533,13 @@ class SnapchatAds:
                                     LOGGER.error('{}'.format(err))
                                     raise
 
-                                # verify primary_keys are in tansformed_record
-                                if 'id' not in transformed_record or 'start_time' not in transformed_record:
-                                    LOGGER.error('Stream: {}, Missing key (id or start_time)'.format(
-                                        stream_name))
-                                    LOGGER.error('transformed_record: {}'.format(transformed_record))
-                                    raise RuntimeError
+                                # Verify all stream primary keys are in the transformed record.
+                                for key in id_fields:
+                                    if not transformed_record.get(key):
+                                        LOGGER.error('Stream: {}, Missing key {}'.format(
+                                            stream_name, key))
+                                        LOGGER.info('transformed_record: {}'.format(transformed_record))
+                                        raise RuntimeError
 
                                 transformed_data.append(transformed_record)
                                 # End for record in records
@@ -566,6 +575,11 @@ class SnapchatAds:
                             if parent and parent_id:
                                 parent_key = parent_key_property or '{}_id'.format(parent)
                                 record.setdefault(parent_key, parent_id)
+                            if parent_replication_key and parent_record:
+                                record.setdefault(
+                                    parent_replication_key,
+                                    parent_record.get(parent_replication_key),
+                                )
 
                             # transform record (remove inconsistent use of CamelCase)
                             try:
@@ -644,7 +658,8 @@ class SnapchatAds:
                                         sync_streams=sync_streams,
                                         selected_streams=selected_streams,
                                         timezone_desc=timezone_desc,
-                                        parent_id=parent_id)
+                                        parent_id=parent_id,
+                                        parent_record=record)
 
                                     LOGGER.info(
                                         'FINISHED Sync for Stream: {}, parent_id: {}, total_records: {}'\
@@ -741,6 +756,7 @@ class Members(SnapchatAds):
     data_key_record = 'member'
     paging = False
     parent = 'organization'
+    parent_replication_key = 'updated_at'
     params = {}
                 
 # Reference: https://developers.snapchat.com/api/docs/?python#get-all-roles-in-organization
@@ -755,6 +771,7 @@ class Roles(SnapchatAds):
     data_key_record = 'role'
     paging = True
     parent = 'organization'
+    parent_replication_key = 'updated_at'
     params = {}
     
 # Reference: https://developers.snapchat.com/api/docs/#get-all-ad-accounts

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -628,14 +628,7 @@ class SnapchatAds:
                                 self.write_schema(catalog, child_stream_name, sync_streams, selected_streams)
                                 # For each parent record
                                 for record in transformed_data:
-                                    i = 0
-                                    # Set parent_id
-                                    for id_field in id_fields:
-                                        if i == 0:
-                                            parent_id_field = id_field
-                                        if id_field == 'id':
-                                            parent_id_field = id_field
-                                        i = i + 1
+                                    parent_id_field = 'id' if 'id' in id_fields else next(iter(id_fields), None)
                                     parent_id = record.get(parent_id_field)
 
                                     if stream_name == 'ad_accounts':

--- a/tap_snapchat_ads/streams.py
+++ b/tap_snapchat_ads/streams.py
@@ -89,6 +89,7 @@ class SnapchatAds:
     params = {}
     parent_stream = None
     parent = None
+    parent_key_property = None
     grandparent_stream = None
     great_grandparent_stream = None
     json_schema = None
@@ -325,6 +326,8 @@ class SnapchatAds:
         data_key_record = stream_class.data_key_record.format(targeting_type=targeting_type)
         id_fields = stream_class.key_properties
         parent = stream_class.parent
+        parent_key_property = stream_class.parent_key_property
+        is_stats_stream = '_stats_' in stream_name or stream_name.endswith('_stats')
         date_window_size = int(stream_class.date_window_size)
         # Store parent_id into base_parent for bookmark writing
         base_parent = parent_id
@@ -345,7 +348,7 @@ class SnapchatAds:
         attribution_window = max(1, swipe_up_attr, view_attr)
 
         omit_empty = config.get('omit_empty') or 'true'
-        if '_stats_' in stream_name:
+        if is_stats_stream:
             params['omit_empty'] = omit_empty
 
         country_codes = config.get('targeting_country_codes') or 'us'
@@ -370,7 +373,7 @@ class SnapchatAds:
         last_dttm = strptime_to_utc(last_datetime)
 
         report_granularity = params.get('granularity', 'HOUR')
-        if '_stats_' in stream_name:
+        if is_stats_stream:
             LOGGER.info('report_granularity: {}'.format(report_granularity))
 
         if bookmark_query_field_from and bookmark_query_field_to:
@@ -495,7 +498,7 @@ class SnapchatAds:
                     transformed_data = [] # initialize the record list
 
                     # Reports stats streams de-nesting
-                    if '_stats_' in stream_name:
+                    if is_stats_stream:
                         for data_record in data.get(data_key_array, []):
                             base_record = data_record.get(data_key_record, {})
                             records = base_record.get('timeseries', [])
@@ -504,6 +507,10 @@ class SnapchatAds:
                                 for key, val in base_record.items():
                                     if key not in ('start_time', 'end_time', 'timeseries'):
                                         record[key] = val
+
+                                if parent and parent_id:
+                                    parent_key = parent_key_property or '{}_id'.format(parent)
+                                    record.setdefault(parent_key, parent_id)
 
                                 # De-nest stats
                                 stats = record.get('stats', {})
@@ -555,10 +562,10 @@ class SnapchatAds:
                                     record['name'] = record_id
                                     record.pop('postalCode')
 
-                            # Add parent id field/value
+                            # Add the parent key when it is absent from the response.
                             if parent and parent_id:
-                                parent_key = '{}_id'.format(parent)
-                                record[parent_key] = parent_id
+                                parent_key = parent_key_property or '{}_id'.format(parent)
+                                record.setdefault(parent_key, parent_id)
 
                             # transform record (remove inconsistent use of CamelCase)
                             try:
@@ -726,9 +733,9 @@ class BillingCenters(SnapchatAds):
 class Members(SnapchatAds):
     tap_stream_id = 'members'
     parent_stream = 'organizations'
-    key_properties = ['id']
-    replication_method = 'FULL_TABLE'
-    replication_keys = []
+    key_properties = ['id', 'organization_id']
+    replication_method = 'INCREMENTAL'
+    replication_keys = ['updated_at']
     path = 'organizations/{parent_id}/members'
     data_key_array = 'members'
     data_key_record = 'member'
@@ -740,8 +747,9 @@ class Members(SnapchatAds):
 class Roles(SnapchatAds):
     tap_stream_id = 'roles'
     parent_stream = 'organizations'
-    key_properties = ['id']
-    replication_method = 'FULL_TABLE'
+    key_properties = ['id', 'organization_id']
+    replication_method = 'INCREMENTAL'
+    replication_keys = ['updated_at']
     path = 'organizations/{parent_id}/roles'
     data_key_array = 'roles'
     data_key_record = 'role'
@@ -853,8 +861,9 @@ class PixelDomainStats(SnapchatAds):
     great_grandparent_stream = 'organizations'
     grandparent_stream = 'ad_accounts'
     parent_stream = 'pixels'
-    key_properties = ['id']
-    replication_method = 'FULL_TABLE'
+    key_properties = ['id', 'pixel_id']
+    replication_method = 'INCREMENTAL'
+    replication_keys = ['end_time']
     path = 'pixels/{parent_id}/domains/stats'
     data_key_array = 'timeseries_stats'
     data_key_record = 'timeseries_stat'
@@ -1137,13 +1146,15 @@ class ProductSets(SnapchatAds):
     tap_stream_id = 'product_sets'
     grandparent_stream = 'organizations'
     parent_stream = 'product_catalogs'
-    key_properties = ['id']
-    replication_method = 'FULL_TABLE'
+    key_properties = ['id', 'catalog_id']
+    replication_method = 'INCREMENTAL'
+    replication_keys = ['updated_at']
     path = 'catalogs/{parent_id}/product_sets'
     data_key_array = 'product_sets'
     data_key_record = 'product_set'
     paging = True
     parent = 'product_catalog'
+    parent_key_property = 'catalog_id'
     params = {}
 
 # DEMO - AGE GROUP

--- a/tests/base.py
+++ b/tests/base.py
@@ -99,6 +99,30 @@ class SnapchatBase(unittest.TestCase):
             self.REPLICATION_KEYS: {"end_time"},
             self.OBEYS_START_DATE: True
         }
+        incremental_end_time_metadata = {
+            self.PRIMARY_KEYS: {"id"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.REPLICATION_KEYS: {"end_time"},
+            self.OBEYS_START_DATE: True
+        }
+        incremental_organization_metadata = {
+            self.PRIMARY_KEYS: {"id", "organization_id"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.REPLICATION_KEYS: {"updated_at"},
+            self.OBEYS_START_DATE: True
+        }
+        incremental_pixel_metadata = {
+            self.PRIMARY_KEYS: {"id", "pixel_id"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.REPLICATION_KEYS: {"end_time"},
+            self.OBEYS_START_DATE: True
+        }
+        incremental_catalog_metadata = {
+            self.PRIMARY_KEYS: {"id", "catalog_id"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.REPLICATION_KEYS: {"updated_at"},
+            self.OBEYS_START_DATE: True
+        }
         full_table_metadata = {
             self.PRIMARY_KEYS: {"id"},
             self.REPLICATION_METHOD: self.FULL_TABLE,
@@ -108,14 +132,14 @@ class SnapchatBase(unittest.TestCase):
             "organizations": incremental_metadata,
             "funding_sources": incremental_metadata,
             "billing_centers": incremental_metadata,
-            "members": full_table_metadata,
-            "roles": full_table_metadata,
+            "members": incremental_organization_metadata,
+            "roles": incremental_organization_metadata,
             "ad_accounts": incremental_metadata,
             "ad_account_stats_daily": stats_metadata,
             "ad_account_stats_hourly": stats_metadata,
             "audience_segments": incremental_metadata,
             "pixels": incremental_metadata,
-            "pixel_domain_stats": full_table_metadata,
+            "pixel_domain_stats": incremental_pixel_metadata,
             "media": incremental_metadata,
             "creatives": incremental_metadata,
             "phone_numbers": incremental_metadata,
@@ -129,7 +153,7 @@ class SnapchatBase(unittest.TestCase):
             "ad_stats_daily": stats_metadata,
             "ad_stats_hourly": stats_metadata,
             "product_catalogs": incremental_metadata,
-            "product_sets": full_table_metadata,
+            "product_sets": incremental_catalog_metadata,
             "targeting_age_groups": full_table_metadata,
             "targeting_genders": full_table_metadata,
             "targeting_languages": full_table_metadata,

--- a/tests/base.py
+++ b/tests/base.py
@@ -99,12 +99,6 @@ class SnapchatBase(unittest.TestCase):
             self.REPLICATION_KEYS: {"end_time"},
             self.OBEYS_START_DATE: True
         }
-        incremental_end_time_metadata = {
-            self.PRIMARY_KEYS: {"id"},
-            self.REPLICATION_METHOD: self.INCREMENTAL,
-            self.REPLICATION_KEYS: {"end_time"},
-            self.OBEYS_START_DATE: True
-        }
         incremental_organization_metadata = {
             self.PRIMARY_KEYS: {"id", "organization_id"},
             self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -12,8 +12,7 @@ class SnapchatAllFieldsTest(SnapchatBase):
             'my_invited_email'
         },
         'members': {
-            'created_at',
-            'updated_at'
+            'created_at'
         },
         'ad_accounts': {
             'lifetime_spend_cap_micro'
@@ -63,8 +62,7 @@ class SnapchatAllFieldsTest(SnapchatBase):
         },
         # These fields are not being replicated from the API, and it is confirmed by the support
         'roles': {
-            'created_at',
-            'updated_at'
+            'created_at'
         },
         # All the streams with 'targeting_*' contains a general schema structure
         # for all the stream. So, all streams will not contain all the fields.

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -129,9 +129,9 @@ class SnapchatStartDateTest(SnapchatBase):
                         start_date_key_value_parsed = parse(start_date_key_value).strftime("%Y-%m-%dT%H:%M:%SZ")
                         self.assertGreaterEqual(self.dt_to_ts(start_date_key_value_parsed), start_date_2_epoch)
 
-                    # Verify the number of records replicated in sync 1 is greater than the number
-                    # of records replicated in sync 2 for stream
-                    self.assertGreater(record_count_sync_1, record_count_sync_2)
+                    # A later start date cannot increase the returned record count. Counts can be
+                    # equal when every record shares a parent-derived replication timestamp.
+                    self.assertGreaterEqual(record_count_sync_1, record_count_sync_2)
 
                     # Verify the records replicated in sync 2 were also replicated in sync 1
                     self.assertTrue(primary_keys_sync_2.issubset(primary_keys_sync_1))

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -76,3 +76,26 @@ class TestDiscover(unittest.TestCase):
         json.dump(catalog.to_dict(), captured, indent=2)
         data = json.loads(captured.getvalue())
         self.assertIn('streams', data)
+
+    def test_child_streams_match_parent_incremental_replication(self):
+        stream_entries = {s.tap_stream_id: s for s in discover().streams}
+        expected = {
+            'members': {'method': 'INCREMENTAL', 'keys': {'updated_at'}, 'primary_keys': {'id', 'organization_id'}},
+            'roles': {'method': 'INCREMENTAL', 'keys': {'updated_at'}, 'primary_keys': {'id', 'organization_id'}},
+            'pixel_domain_stats': {'method': 'INCREMENTAL', 'keys': {'end_time'}, 'primary_keys': {'id', 'pixel_id'}},
+            'product_sets': {'method': 'INCREMENTAL', 'keys': {'updated_at'}, 'primary_keys': {'id', 'catalog_id'}},
+        }
+
+        for stream_name, expectation in expected.items():
+            with self.subTest(stream=stream_name):
+                stream_entry = stream_entries[stream_name]
+                root_md = next(m for m in stream_entry.metadata if m.get('breadcrumb') == ())
+                self.assertEqual(
+                    root_md['metadata'].get('forced-replication-method'),
+                    expectation['method'],
+                )
+                self.assertSetEqual(
+                    set(root_md['metadata'].get('valid-replication-keys', [])),
+                    expectation['keys'],
+                )
+                self.assertSetEqual(set(stream_entry.key_properties), expectation['primary_keys'])

--- a/tests/unittests/test_parent_child_independent.py
+++ b/tests/unittests/test_parent_child_independent.py
@@ -9,6 +9,8 @@ from singer import metadata as singer_metadata
 from singer import utils as singer_utils
 from tap_snapchat_ads.streams import (
     SnapchatAds,
+    Members,
+    PixelDomainStats,
     ALL_STATS_FIELDS,
     get_hourly_stats_fields,
     _to_snake_case,
@@ -326,6 +328,79 @@ class TestProcessRecords(unittest.TestCase):
             last_datetime='2021-01-01T00:00:00Z',
         )
         self.assertGreater(max_bm, '2021-01-01T00:00:00Z')
+
+
+# ---------------------------------------------------------------------------
+# parent key injection
+# ---------------------------------------------------------------------------
+
+class TestParentKeyInjection(unittest.TestCase):
+    @mock.patch('tap_snapchat_ads.streams.singer.messages.write_record')
+    def test_members_injects_organization_id(self, mock_write):
+        schema = {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string'},
+                'organization_id': {'type': 'string'},
+                'updated_at': {'type': 'string', 'format': 'date-time'},
+            },
+        }
+        SnapchatAds().sync_endpoint(
+            client=_make_mock_client({
+                'request_status': 'SUCCESS',
+                'members': [{
+                    'sub_request_status': 'SUCCESS',
+                    'member': {'id': 'member-1', 'updated_at': '2022-01-01T00:00:00Z'},
+                }],
+            }),
+            config={'start_date': '2021-01-01T00:00:00Z'},
+            catalog=_MockCatalog(schema_dict=schema),
+            state={},
+            stream_name='members',
+            stream_class=Members,
+            sync_streams=['members'],
+            selected_streams=['members'],
+            parent_id='organization-1',
+        )
+
+        self.assertEqual(mock_write.call_args.args[1]['organization_id'], 'organization-1')
+
+    @mock.patch('tap_snapchat_ads.streams.singer.messages.write_record')
+    def test_pixel_domain_stats_injects_pixel_id(self, mock_write):
+        schema = {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string'},
+                'pixel_id': {'type': 'string'},
+                'start_time': {'type': 'string', 'format': 'date-time'},
+                'end_time': {'type': 'string', 'format': 'date-time'},
+            },
+        }
+        SnapchatAds().sync_endpoint(
+            client=_make_mock_client({
+                'request_status': 'SUCCESS',
+                'timeseries_stats': [{
+                    'timeseries_stat': {
+                        'id': 'domain-1',
+                        'timeseries': [{
+                            'start_time': '2022-01-01T00:00:00Z',
+                            'end_time': '2022-01-02T00:00:00Z',
+                            'stats': {},
+                        }],
+                    },
+                }],
+            }),
+            config={'start_date': '2021-01-01T00:00:00Z'},
+            catalog=_MockCatalog(schema_dict=schema),
+            state={},
+            stream_name='pixel_domain_stats',
+            stream_class=PixelDomainStats,
+            sync_streams=['pixel_domain_stats'],
+            selected_streams=['pixel_domain_stats'],
+            parent_id='pixel-1',
+        )
+
+        self.assertEqual(mock_write.call_args.args[1]['pixel_id'], 'pixel-1')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittests/test_parent_child_independent.py
+++ b/tests/unittests/test_parent_child_independent.py
@@ -366,6 +366,37 @@ class TestParentKeyInjection(unittest.TestCase):
         self.assertEqual(mock_write.call_args.args[1]['organization_id'], 'organization-1')
 
     @mock.patch('tap_snapchat_ads.streams.singer.messages.write_record')
+    def test_members_uses_parent_updated_at_when_missing(self, mock_write):
+        schema = {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string'},
+                'organization_id': {'type': 'string'},
+                'updated_at': {'type': 'string', 'format': 'date-time'},
+            },
+        }
+        SnapchatAds().sync_endpoint(
+            client=_make_mock_client({
+                'request_status': 'SUCCESS',
+                'members': [{
+                    'sub_request_status': 'SUCCESS',
+                    'member': {'id': 'member-1'},
+                }],
+            }),
+            config={'start_date': '2021-01-01T00:00:00Z'},
+            catalog=_MockCatalog(schema_dict=schema),
+            state={},
+            stream_name='members',
+            stream_class=Members,
+            sync_streams=['members'],
+            selected_streams=['members'],
+            parent_id='organization-1',
+            parent_record={'id': 'organization-1', 'updated_at': '2022-01-01T00:00:00Z'},
+        )
+
+        self.assertEqual(mock_write.call_args.args[1]['updated_at'], '2022-01-01T00:00:00.000000Z')
+
+    @mock.patch('tap_snapchat_ads.streams.singer.messages.write_record')
     def test_pixel_domain_stats_injects_pixel_id(self, mock_write):
         schema = {
             'type': 'object',
@@ -401,6 +432,70 @@ class TestParentKeyInjection(unittest.TestCase):
         )
 
         self.assertEqual(mock_write.call_args.args[1]['pixel_id'], 'pixel-1')
+
+    def test_pixel_domain_stats_requires_pixel_id(self):
+        schema = {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string'},
+                'pixel_id': {'type': 'string'},
+                'start_time': {'type': 'string', 'format': 'date-time'},
+                'end_time': {'type': 'string', 'format': 'date-time'},
+            },
+        }
+        with self.assertRaises(RuntimeError):
+            SnapchatAds().sync_endpoint(
+                client=_make_mock_client({
+                    'request_status': 'SUCCESS',
+                    'timeseries_stats': [{
+                        'timeseries_stat': {
+                            'id': 'domain-1',
+                            'timeseries': [{
+                                'start_time': '2022-01-01T00:00:00Z',
+                                'end_time': '2022-01-02T00:00:00Z',
+                                'stats': {},
+                            }],
+                        },
+                    }],
+                }),
+                config={'start_date': '2021-01-01T00:00:00Z'},
+                catalog=_MockCatalog(schema_dict=schema),
+                state={},
+                stream_name='pixel_domain_stats',
+                stream_class=PixelDomainStats,
+                sync_streams=['pixel_domain_stats'],
+                selected_streams=['pixel_domain_stats'],
+            )
+
+
+class TestSyncEndpointParams(unittest.TestCase):
+    def test_does_not_mutate_class_params(self):
+        class StreamWithParams(SnapchatAds):
+            tap_stream_id = 'stream_with_params'
+            key_properties = ['id']
+            replication_method = 'FULL_TABLE'
+            replication_keys = []
+            path = 'stream_with_params'
+            data_key_array = 'records'
+            data_key_record = 'record'
+            paging = True
+            params = {'attribution_window': '{swipe_up_attribution_window}'}
+
+        SnapchatAds().sync_endpoint(
+            client=_make_mock_client({'request_status': 'SUCCESS', 'records': []}),
+            config={'start_date': '2021-01-01T00:00:00Z'},
+            catalog=_MockCatalog(),
+            state={},
+            stream_name='stream_with_params',
+            stream_class=StreamWithParams,
+            sync_streams=['stream_with_params'],
+            selected_streams=['stream_with_params'],
+        )
+
+        self.assertEqual(
+            StreamWithParams.params,
+            {'attribution_window': '{swipe_up_attribution_window}'},
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description of change
This PR updates the child streams to use INCREMENTAL replication into each emitted record, along with schema/test updates and a version bump. [SAC-31809](https://qlik-dev.atlassian.net/browse/SAC-31809).
Along with parent t key properties when saving records. [SAC-31920](https://qlik-dev.atlassian.net/browse/SAC-31920).

Changes:

- Convert Child streams from FullTableStream to ChildBaseStream and switch replication method to INCREMENTAL with replication_keys = ["updated_at"].

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
